### PR TITLE
import :std/assert

### DIFF
--- a/secp256k1-ffi.ss
+++ b/secp256k1-ffi.ss
@@ -34,7 +34,10 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exceptions :gerbil/gambit/threads
-  :std/foreign :std/misc/bytes :std/text/hex :std/sugar :std/assert
+  :std/assert :std/foreign
+  :std/misc/bytes
+  :std/sugar
+  :std/text/hex
   :clan/base)
 
 (begin-ffi

--- a/secp256k1-ffi.ss
+++ b/secp256k1-ffi.ss
@@ -34,7 +34,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exceptions :gerbil/gambit/threads
-  :std/foreign :std/misc/bytes :std/text/hex :std/sugar
+  :std/foreign :std/misc/bytes :std/text/hex :std/sugar :std/assert
   :clan/base)
 
 (begin-ffi

--- a/t/random-test.ss
+++ b/t/random-test.ss
@@ -1,7 +1,7 @@
 (export #t)
 
 (import :gerbil/gambit/bits
-        :std/iter :std/sugar :std/test
+        :std/iter :std/sugar :std/assert :std/test
         ../random)
 
 (def random-test

--- a/t/random-test.ss
+++ b/t/random-test.ss
@@ -1,7 +1,7 @@
 (export #t)
 
 (import :gerbil/gambit/bits
-        :std/iter :std/sugar :std/assert :std/test
+        :std/assert :std/iter :std/sugar :std/test
         ../random)
 
 (def random-test


### PR DESCRIPTION
After https://github.com/vyzo/gerbil/pull/644, `assert!` has been moved from `:std/sugar` to a new module `:std/assert`, so we need to import `:std/assert`.